### PR TITLE
add Anna Godwin lightning talk links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A community-built list of resources coming out of [Normconf](https://normconf.co
 | Speaker | Talk Video | Slides |
 |---------|------------|--------|
 |Randy Au         |  [Video](https://youtu.be/-6sS3wVYpM8)          | [Slides](https://docs.google.com/presentation/d/1hmtZ1Hpm2M4lEEEHfVWl6-zX_aVhdjQQ5JxK8dUzqPM/edit?usp=sharing)        |
-|         |            |        |
+|Anna Godwin         |  [Video](https://www.youtube.com/watch?v=rB_yaWEHhtM)          |  [Slides](https://github.com/annagodwin/normconf-intro-pdf/blob/main/NormConf%20Intro%20PDF%20Extraction.pdf)  / [Code Snippets](https://github.com/annagodwin/normconf-intro-pdf/blob/main/README.md)    |
 |         |            |        |
 |         |            |        |
 |         |            |        |


### PR DESCRIPTION
updated `README.md` to include links to Anna Godwin's Lightning Talk video, slides, and code snippets