### PR TITLE
Add interest level planning tool for talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ A community-built list of resources coming out of [NormConf](https://normconf.co
 ## Awesome NormConf Extras
 
 + [Bingo Card Template](https://docs.google.com/document/d/16DbU2xWBabk-R2FqmpAlOJoPqEnToxQ5qDJiVQu9NKI/edit?usp=sharing)
++ [Interest Level Planning Tool for Talks](https://docs.google.com/spreadsheets/d/1IFB8oEnyceZQCCubdD5k4ToARZ4nV822alHFSl9nMus/edit?usp=sharing)


### PR DESCRIPTION
Blank template one for everyone to use and help pick which talks they're most interested in (based solely on the title).